### PR TITLE
[Feature] Front end Url Validation in Profile

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -142,18 +142,13 @@ class NodeSerializer(JSONAPISerializer):
         for deleted_tag in (old_tags - current_tags):
             node.remove_tag(deleted_tag, auth=auth)
 
-        if 'is_public' in validated_data:
-            privacy_key = 'public' if validated_data.pop('is_public') else 'private'
-            try:
-                node.set_privacy(privacy_key, auth=auth, log=True, save=True)
-            except PermissionsError:
-                raise exceptions.PermissionDenied
-
         if validated_data:
             try:
                 node.update(validated_data, auth=auth)
             except ValidationValueError as e:
                 raise InvalidModelValueError(detail=e.message)
+            except PermissionsError:
+                raise exceptions.PermissionDenied
 
         return node
 

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -966,7 +966,7 @@ class TestNodeUpdate(NodeCRUDTestCase):
         assert_equal(res.json['data']['attributes']['title'], strip_html(new_title))
         assert_equal(res.json['data']['attributes']['description'], strip_html(new_description))
 
-    @assert_logs(NodeLog.UPDATED_FIELDS, 'public_project')
+    @assert_logs(NodeLog.EDITED_TITLE, 'public_project')
     def test_partial_update_project_updates_project_correctly_and_sanitizes_html(self):
         new_title = 'An <script>alert("even cooler")</script> project'
         res = self.app.patch_json_api(self.public_url, {
@@ -1014,7 +1014,7 @@ class TestNodeUpdate(NodeCRUDTestCase):
         assert_equal(res.status_code, 401)
         assert_in('detail', res.json['errors'][0])
 
-    @assert_logs(NodeLog.UPDATED_FIELDS, 'public_project')
+    @assert_logs(NodeLog.EDITED_TITLE, 'public_project')
     def test_partial_update_public_project_logged_in(self):
         res = self.app.patch_json_api(self.public_url, {
             'data': {
@@ -1057,7 +1057,7 @@ class TestNodeUpdate(NodeCRUDTestCase):
         assert_equal(res.status_code, 401)
         assert_in('detail', res.json['errors'][0])
 
-    @assert_logs(NodeLog.UPDATED_FIELDS, 'private_project')
+    @assert_logs(NodeLog.EDITED_TITLE, 'private_project')
     def test_partial_update_private_project_logged_in_contributor(self):
         res = self.app.patch_json_api(self.private_url, {
             'data': {

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1894,6 +1894,28 @@ class TestNodeUpdate(OsfTestCase):
         last_log = self.node.logs[-1]
         assert_equal(last_log.action, NodeLog.MADE_PRIVATE)
 
+    def test_updating_title_twice_with_same_title(self):
+        original_n_logs = len(self.node.logs)
+        new_title = fake.bs()
+        self.node.update({'title': new_title}, auth=Auth(self.user), save=True)
+        assert_equal(len(self.node.logs), original_n_logs + 1)  # sanity check
+
+        # Call update with same title
+        self.node.update({'title': new_title}, auth=Auth(self.user), save=True)
+        # A new log is not created
+        assert_equal(len(self.node.logs), original_n_logs + 1)
+
+    def test_updating_description_twice_with_same_content(self):
+        original_n_logs = len(self.node.logs)
+        new_desc = fake.bs()
+        self.node.update({'description': new_desc}, auth=Auth(self.user), save=True)
+        assert_equal(len(self.node.logs), original_n_logs + 1)  # sanity check
+
+        # Call update with same description
+        self.node.update({'description': new_desc}, auth=Auth(self.user), save=True)
+        # A new log is not created
+        assert_equal(len(self.node.logs), original_n_logs + 1)
+
     # TODO: test permissions, non-writable fields
 
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -14,7 +14,7 @@ import time
 from nose.tools import *  # noqa PEP8 asserts
 from tests.test_features import requires_search
 
-from modularodm import Q, fields
+from modularodm import Q
 from modularodm.exceptions import ValidationError
 from dateutil.parser import parse as parse_date
 
@@ -245,7 +245,6 @@ class TestProjectViews(OsfTestCase):
         assert_false(ret)
         self.project.reload()
         assert_true(self.project.is_contributor(self.user2))
-
 
     def test_can_view_nested_project_as_admin(self):
         self.parent_project = NodeFactory(
@@ -639,7 +638,6 @@ class TestProjectViews(OsfTestCase):
         assert_equal(res.status_code, 200)
         assert_equal(len(data['errors']), 2)
 
-
     # Regression test for https://github.com/CenterForOpenScience/osf.io/issues/1478
     @mock.patch('website.archiver.tasks.archive')
     def test_registered_projects_contributions(self, mock_archive):
@@ -974,6 +972,22 @@ class TestProjectViews(OsfTestCase):
         res = self.app.get(url, auth=self.auth)
         assert_equal(res.status_code, 302)
         assert_in(self.project.web_url_for('project_statistics', _guid=True), res.location)
+
+    def test_update_node(self):
+        url = self.project.api_url_for('update_node')
+        res = self.app.put_json(url, {'title': 'newtitle'}, auth=self.auth)
+        assert_equal(res.status_code, 200)
+        self.project.reload()
+        assert_equal(self.project.title, 'newtitle')
+
+    # Regression test
+    def test_update_node_with_tags(self):
+        self.project.add_tag('cheezebørger', auth=Auth(self.project.creator), save=True)
+        url = self.project.api_url_for('update_node')
+        res = self.app.put_json(url, {'title': 'newtitle'}, auth=self.auth)
+        assert_equal(res.status_code, 200)
+        self.project.reload()
+        assert_equal(self.project.title, 'newtitle')
 
 
 class TestEditableChildrenViews(OsfTestCase):

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -1649,7 +1649,11 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
         validate_title(title)
 
         original_title = self.title
-        self.title = sanitize.strip_html(title)
+        new_title = sanitize.strip_html(title)
+        # Title hasn't changed after sanitzation, bail out
+        if original_title == new_title:
+            return False
+        self.title = new_title
         self.add_log(
             action=NodeLog.EDITED_TITLE,
             params={
@@ -1673,7 +1677,10 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
         :param bool save: Save self after updating.
         """
         original = self.description
-        self.description = sanitize.strip_html(description)
+        new_description = sanitize.strip_html(description)
+        if original == new_description:
+            return False
+        self.description = new_description
         self.add_log(
             action=NodeLog.EDITED_DESCRIPTION,
             params={

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -581,6 +581,7 @@ def update_node(auth, node, **kwargs):
         updated_fields_dict = {
             key: getattr(node, key) if key != 'tags' else [str(tag) for tag in node.tags]
             for key in updated_field_names
+            if key != 'logs'
         }
         return {
             'updated_fields': updated_fields_dict

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -576,12 +576,14 @@ def update_node(auth, node, **kwargs):
     # category, title, and discription which can be edited by write permission contributor
     data = r_strip_html(request.get_json())
     try:
+        updated_field_names = node.update(data, auth=auth)
+        # Need to cast tags to a string to make them JSON-serialiable
+        updated_fields_dict = {
+            key: getattr(node, key) if key != 'tags' else [str(tag) for tag in node.tags]
+            for key in updated_field_names
+        }
         return {
-            'updated_fields': {
-                key: getattr(node, key)
-                for key in
-                node.update(data, auth=auth)
-            }
+            'updated_fields': updated_fields_dict
         }
     except NodeUpdateError as e:
         raise HTTPError(400, data=dict(

--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -57,7 +57,7 @@ var SharePopover =  {
                             m('input.form-control[readonly][type="text"][value="'+ link +'"]')
                         ])),
                         m('.tab-pane#embed', [
-                            m('p', 'Dynamically Render iFrame with JavaScript'),
+                            m('p', 'Dynamically render iframe with JavaScript'),
                             m('textarea.form-control[readonly][type="text"][value="' +
                                 '<script>window.jQuery || document.write(\'<script src="//code.jquery.com/jquery-1.11.2.min.js">\\x3C/script>\') </script>'+
                                 '<link href="' + url + 'static/css/mfr.css" media="all" rel="stylesheet">' +
@@ -67,7 +67,7 @@ var SharePopover =  {
                                     'var mfrRender = new mfr.Render("mfrIframe", "' + link + '");' +
                                 '</script>' + '"]'
                             ), m('br'),
-                            m('p', 'Direct iFrame with Fixed Height and Width'),
+                            m('p', 'Direct iframe with fixed height and width'),
                             m('textarea.form-control[readonly][value="' +
                                 '<iframe src="' + link + '" width="100%" scrolling="yes" height="' + params.height + '" marginheight="0" frameborder="0" allowfullscreen webkitallowfullscreen>"]'
                             )

--- a/website/static/js/licensePicker.js
+++ b/website/static/js/licensePicker.js
@@ -118,9 +118,13 @@ var LicensePicker = oop.extend(ChangeMessageMixin, {
             return null;
         });
         self.selectedLicenseText = ko.computed(function() {
-            return self.selectedLicense().text
-                .replace('{{year}}', self.year())
-                .replace('{{copyrightHolders}}', self.copyrightHolders());
+            if (self.selectedLicense().text) {
+                return self.selectedLicense().text
+                    .replace('{{year}}', self.year())
+                    .replace('{{copyrightHolders}}', self.copyrightHolders());
+            } else{
+                return '';
+            }
         });
 
         self.validProps = ko.computed(function() {
@@ -205,33 +209,7 @@ var LicensePicker = oop.extend(ChangeMessageMixin, {
                 data: JSON.stringify(payload)
             }).done(self.onSaveSuccess.bind(self, selectedLicense)).fail(self.onSaveFail.bind(self));
         };
-        if (license.id === OTHER_LICENSE.id) {
-            var ret = $.Deferred();
-            bootbox.dialog({
-                title: 'Your Own License',
-                message: 'You have opted to use your own license. Please upload a license file named "license.txt" into the OSF Storage of this project.',
-                buttons: {
-                    cancel: {
-                        label: 'Cancel',
-                        className: 'btn btn-default'
-                    },
-                    main: {
-                        label: 'OK',
-                        className: 'btn btn-primary',
-                        callback: function(confirmed) {
-                            if (confirmed) {
-                                save().then(ret.resolve);
-                            } else {
-                                ret.reject();
-                            }
-                        }
-                    }
-                }
-            });
-            return ret.promise();
-        } else {
-            return save();
-        }
+        return save();
     }
 });
 

--- a/website/static/js/licenses.js
+++ b/website/static/js/licenses.js
@@ -14,8 +14,7 @@ var DEFAULT_LICENSE = {
 };
 var OTHER_LICENSE = {
     id: 'OTHER',
-    name: 'License not listed - choose to add',
-    text: 'Please see the "license.txt" uploaded in this project\'s OSF Storage'
+    name: 'License - Other'
 };
 list.unshift(DEFAULT_LICENSE);
 list.push(OTHER_LICENSE);
@@ -47,4 +46,3 @@ module.exports = {
     OTHER_LICENSE: OTHER_LICENSE,
     groups: licenseGroups
 };
-    

--- a/website/static/js/tests/licensePicker.test.js
+++ b/website/static/js/tests/licensePicker.test.js
@@ -54,10 +54,8 @@ describe('LicensePicker', () => {
         });
     });
     describe('#save', () => {
-        var dialogStub;
         var ajaxStub;
         beforeEach(() => {
-            dialogStub = sinon.stub(bootbox, 'dialog');
             ajaxStub = sinon.stub($, 'ajax', function() {
                 var ret = $.Deferred();
                 ret.resolve();
@@ -66,7 +64,6 @@ describe('LicensePicker', () => {
             sinon.stub(lp, 'disableSave', function() {return false;});
         });
         afterEach(() => {
-            bootbox.dialog.restore();
             $.ajax.restore();
             if (lp.disableSave.restore) {
                 lp.disableSave.restore();
@@ -75,13 +72,7 @@ describe('LicensePicker', () => {
         it('returns without saving if required fields are missing', () => {
             lp.disableSave.restore();
             lp.save();
-            assert.isFalse(dialogStub.called);
             assert.isFalse(ajaxStub.called);
-        });
-        it('asks confirmation if the user has selected the OTHER license', () => {
-            lp.selectedLicenseId('OTHER');
-            lp.save();
-            assert.calledOnce(dialogStub);
         });
         it('otherwise makes a request based on the value of saveUrl, saveMethod, and saveLicenseKey', (done) => {
             lp.selectedLicenseId('MIT');

--- a/website/static/js/tests/licensePicker.test.js
+++ b/website/static/js/tests/licensePicker.test.js
@@ -56,7 +56,7 @@ describe('LicensePicker', () => {
     describe('#save', () => {
         var dialogStub;
         var ajaxStub;
-        beforeEach(() => {            
+        beforeEach(() => {
             dialogStub = sinon.stub(bootbox, 'dialog');
             ajaxStub = sinon.stub($, 'ajax', function() {
                 var ret = $.Deferred();
@@ -95,9 +95,9 @@ describe('LicensePicker', () => {
                     contentType: 'application/json',
                     data: JSON.stringify(payload)
                 };
-                assert.isTrue(ajaxStub.calledWith(args));                             
+                assert.isTrue(ajaxStub.calledWith(args));
                 done();
-            }); 
+            });
         });
     });
 });

--- a/website/static/templates/license-picker.html
+++ b/website/static/templates/license-picker.html
@@ -20,7 +20,7 @@
             <div class="form-inline">
                 <div class="form-group">
                     <label> Choose a license: </label>
-                    <select class="form-control" data-bind="groupOptions: licenseGroups, 
+                    <select class="form-control" data-bind="groupOptions: licenseGroups,
                                                             value: selectedLicenseId,
                                                             optionsText: 'name',
                                                             optionsValue: 'id'">
@@ -40,7 +40,7 @@
               </div>
             </div>
         </div>
-        <div class="col-md" style="width:100%" data-bind="if: previewing">
+        <div class="col-md" style="width:100%" data-bind="if: previewing && selectedLicenseText()">
             <pre data-bind="text: selectedLicenseText" style="border:none;width:100%;text-align:justify"></pre>
         </div>
         <button class="btn btn-success pull-right" data-bind="click: save,


### PR DESCRIPTION
Fixes #3149 

The knockout front end URL validation does not work for observable arrays.  So, bad urls such as 

```
http://&lt;/script&gt;&lt;script&gt;alert(“Now I am doing bad stuff”)&lt;/script&gt;
```

and 

```
&lt;/script&gt;&lt;script&gt;alert(“Now I am doing bad stuff”)&lt;/script&gt;
```

generate either 400 or 500 errors on the server.

This update stops incorrect requests from being sent, giving relevant error messaging and greying out the Send button if a bad url is entered.
